### PR TITLE
vhost-user: avoid process slave message twice; skip non-vhost user devices

### DIFF
--- a/hw/virtio/vhost-user.c
+++ b/hw/virtio/vhost-user.c
@@ -217,11 +217,16 @@ static int vhost_dev_slave_read(struct vhost_dev *dev) {
     r = ioctl(u->slave_fd, FIONREAD, &bytes);
     if (r)  {
         error_report("Failed to read client msg bytes %d", r);
+        return -1;
     } else if (bytes) {
         /* Client message available */
+        qemu_set_fd_handler(u->slave_fd, NULL, NULL, NULL);
         slave_read(dev);
+        qemu_set_fd_handler(u->slave_fd, slave_read, NULL, dev);
+        return 1;
+    } else {
+        return 0;
     }
-    return 1;
 }
 
 static int vhost_user_progress_slave(struct vhost_user *u) {

--- a/hw/virtio/vhost-user.c
+++ b/hw/virtio/vhost-user.c
@@ -212,6 +212,8 @@ static int vhost_dev_slave_read(struct vhost_dev *dev) {
     int bytes = 0;
     int r;
 
+    if (dev->vhost_ops->backend_type != VHOST_BACKEND_TYPE_USER)
+        return 0;
     if (u->slave_fd < 0)
         return 0;
     r = ioctl(u->slave_fd, FIONREAD, &bytes);

--- a/hw/virtio/vhost.c
+++ b/hw/virtio/vhost.c
@@ -51,10 +51,12 @@ static QLIST_HEAD(, vhost_dev) vhost_devices =
 int vhost_for_each_device(vhost_dev_cb cb)
 {
     struct vhost_dev *hdev;
-    int result = 0;
+    int result = 0, ret;
 
     QLIST_FOREACH(hdev, &vhost_devices, entry) {
-        result = cb(hdev);
+        ret = cb(hdev);
+        if (ret > 0)
+            result += ret;
     }
     return result;
 }


### PR DESCRIPTION
If processed slave fd in message handler, qemu main fd loop callback
will read it again and fall into endless wait.

This patch remove slave fd handler temporarily from qemu main loop.

Fixes: 2107293000 ("vhost-user: avoid slave socket stuck")
Signed-off-by: Xueming Li <xuemingl@mellanox.com>