### PR TITLE
memory: add memory region validity check after lock

### DIFF
--- a/exec.c
+++ b/exec.c
@@ -3090,6 +3090,10 @@ static MemTxResult flatview_write_continue(FlatView *fv, hwaddr addr,
     for (;;) {
         if (!memory_access_is_direct(mr, true)) {
             release_lock |= prepare_mmio_access(mr);
+            if (release_lock && !__atomic_load_n(&mr->enabled, __ATOMIC_ACQUIRE)) {
+                qemu_mutex_unlock_iothread();
+                return MEMTX_ERROR;
+            }
             l = memory_access_size(mr, l, addr1);
             /* XXX: could force current_cpu to NULL to avoid
                potential bugs */


### PR DESCRIPTION
When writing a memory, MR is retrieved before applying control
path lock, could be removed in control path before acquiring lock.

This patch adds MR validity check after control path lock, returns
error if MR no longer valid.

Signed-off-by: Xueming Li <xuemingl@nvidia.com>