### PR TITLE
io: fix io peek on disconnection

### DIFF
--- a/chardev/char-socket.c
+++ b/chardev/char-socket.c
@@ -489,8 +489,11 @@ static gboolean tcp_chr_hup(QIOChannel *channel,
 static int tcp_chr_peek(Chardev *chr)
 {
     SocketChardev *s = SOCKET_CHARDEV(chr);
-    QIOChannelClass *klass = QIO_CHANNEL_GET_CLASS(s->ioc);
+    QIOChannelClass *klass;
 
+    if (!s->ioc)
+        return -1;
+    klass = QIO_CHANNEL_GET_CLASS(s->ioc);
     return klass->io_peek(s->ioc, NULL);
 }
 


### PR DESCRIPTION
If vhost client killed, socket is removed, segment fault when access
socket.

Fixes: 28d906569259 ("io: support peek function"

Signed-off-by: Xueming Li <xuemingl@nvidia.com>
